### PR TITLE
Upgrade to Quarkus 3.0

### DIFF
--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/monitoring/LivenessHealthCheck.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/monitoring/LivenessHealthCheck.java
@@ -8,7 +8,7 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @Liveness
 @ApplicationScoped

--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/monitoring/ReadinessHealthCheck.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/monitoring/ReadinessHealthCheck.java
@@ -8,7 +8,7 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @Readiness
 @ApplicationScoped

--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/v1/CompasSitipeResource.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/v1/CompasSitipeResource.java
@@ -8,13 +8,13 @@ import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Uni;
 import org.lfenergy.compas.sitipe.service.CompasSitipeService;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 // @Authenticated
 @RequestScoped

--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/v2/CompasSitipeResource.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/v2/CompasSitipeResource.java
@@ -7,13 +7,13 @@ package org.lfenergy.compas.sitipe.rest.v2;
 import io.smallrye.mutiny.Uni;
 import org.lfenergy.compas.sitipe.service.CompasSitipeService;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 // @Authenticated
 @RequestScoped

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,8 @@ SPDX-License-Identifier: Apache-2.0
         <sonarqube-plugin.version>3.2.0</sonarqube-plugin.version>
 
         <compas.core.version>0.12.0</compas.core.version>
-        <quarkus.platform.version>2.16.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.0.4.Final</quarkus.platform.version>
 
-        <jaxb-impl.version>2.3.8</jaxb-impl.version>
         <microprofile-openapi-api.version>3.1</microprofile-openapi-api.version>
         <log4j2.version>2.20.0</log4j2.version>
         <openpojo.version>0.9.1</openpojo.version>
@@ -57,8 +56,8 @@ SPDX-License-Identifier: Apache-2.0
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-universe-bom</artifactId>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -89,12 +88,6 @@ SPDX-License-Identifier: Apache-2.0
                 <groupId>org.lfenergy.compas.core</groupId>
                 <artifactId>websocket-commons</artifactId>
                 <version>${compas.core.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${jaxb-impl.version}</version>
             </dependency>
 
             <dependency>

--- a/repository/src/main/java/org/lfenergy/compas/sitipe/data/repository/SitipeRepository.java
+++ b/repository/src/main/java/org/lfenergy/compas/sitipe/data/repository/SitipeRepository.java
@@ -6,7 +6,7 @@ package org.lfenergy.compas.sitipe.data.repository;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class SitipeRepository implements PanacheRepository<Object> {

--- a/service/src/main/java/org/lfenergy/compas/sitipe/service/CompasSitipeService.java
+++ b/service/src/main/java/org/lfenergy/compas/sitipe/service/CompasSitipeService.java
@@ -6,8 +6,8 @@ package org.lfenergy.compas.sitipe.service;
 
 import org.lfenergy.compas.sitipe.data.repository.SitipeRepository;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * Service class that will be using a Repository instance to retrieve, Sitipe configuration.


### PR DESCRIPTION
- update Quarkus bom from `io.quarkus:quarkus-universe-bom` to `io.quarkus.platform:quarkus-bom` as it was deprecated since Quarkus 2.1 https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.1#quarkus-universe-bom-is-deprecated (and it is required to use the Quarkus migration tool)
- launched quarkus `quarkus update --stream=3.0` as mentioned in https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#automatic-update-tool which dealt with a fair part of the migration. Then it remained few little tasks.
- removed no more necessary com.sun.xml.bind:jaxb-impl

fixes #4

requires https://github.com/com-pas/compas-core/pull/230